### PR TITLE
Initial commit for the Development Container config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+	"name": "Open PineBuds Pro - VS Code Development Environment",
+	"build": {
+		"dockerfile": "../Dockerfile",
+		"context": ".."
+	},
+	"extensions": [
+		"ms-vscode.cmake-tools",
+		"ms-vscode.cpptools"
+	],
+	"runArgs": [
+		"--privileged"
+	],
+	"userEnvProbe": "loginInteractiveShell",
+	"remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 !.gitattributes
 !.mailmap
 !.github
+!.devcontainer
 
 # Backup files
 *~


### PR DESCRIPTION
This commit adds a .devcontainer directory, with the Dockerfile in the configuration told to use the Dockerfile in the parent directory.

Using Development Containers means the environment is reproducible on developer machines,
and reduces the barrier to entry for development. It also allows GitHub Codespaces to be used.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>