### PR TITLE
Add container build workflow, and Dependabot

### DIFF
--- a/.github/workflows/build-and-push-to-registry.yml
+++ b/.github/workflows/build-and-push-to-registry.yml
@@ -1,0 +1,34 @@
+name: Container image builder workflow
+on:
+  push:
+  workflow_dispatch:
+
+concurrency:
+  group: gh-ref-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push-images:
+    name: Build and push container image for PineBuds Pro SDK to GHCR.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Build images
+        id: build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ github.repository }}
+          context: /
+          tags: ${{ contains(github.ref_name, 'main') && 'latest' || github.ref_name }}-sdk
+          containerfiles: /Dockerfile
+
+      - name: Push container
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build.outputs.image }}
+          tags: ${{ steps.build.outputs.tags }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 !.gitignore
 !.gitattributes
 !.mailmap
+!.github
 
 # Backup files
 *~


### PR DESCRIPTION
This commit adds support for Dependabot, and a container build workflow, that, upon pushes to the repo, but *not* pull requests, builds a container image at one at a time, and pushes to GitHub Registry.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>