### PR TITLE
Add backup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.BAK
 *.orig
 \#*#
+firmware-backups/
 
 # Tag files
 /tags

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ In order to program the buds from inside of the docker container; privileged mod
 ./build.sh # This will run make and build the output program. If you have weird build errors try running clean.sh or rm -rf'ing the out folder first
 
 # Now that the firmware has finished building; if there are no errors you can load it to your buds
+
+# You may want to back up the firmware currently on the buds - it will be deleted when the new firmware is loaded on:
+./backup.sh
+
 # You may need to take the buds out of the case, wait three seconds, place them back. This wakes them up and the programmer needs to catch this reboot.
 
 # You can try the helper script by running

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+BKPPATH="firmware-backups"
+
+mkdir -p $BKPPATH
+
+NOW=$(date +%s)
+
+num=$(ls -l /dev/ttyACM* | rev | cut -c 1)
+echo com is:$num
+splitPorts=($num)
+echo "This tool assumes your buds are the only thing connected and are enumerated {right,left} order. YMMV"
+echo "Right bud is at ${splitPorts[0]}"
+echo "Left bud is at ${splitPorts[1]}"
+
+echo "Please disconnect and reconnect the bud on the right"
+
+bestool read-image --port /dev/ttyACM${splitPorts[0]} $BKPPATH/firmware-$NOW-${splitPorts[0]}.bin.bkp
+
+echo "Please disconnect and reconnect the bud on the left"
+bestool read-image --port /dev/ttyACM${splitPorts[1]} $BKPPATH/firmware-$NOW-${splitPorts[1]}.bin.bkp


### PR DESCRIPTION
I put together a script called `backup.sh` that handles creating firmware backups with `bestool`. The script is based on `./download.sh` and is still pretty similar to it. The script places firmware backups in `firmware-backups/` with names like `firmware-1672882716-0.bin.bkp`, where `1672882716` is the UNIX time at the start of the script and `-0` indicates the firmware is from the right bud. A `-1` indicates it's from the left.