### PR TITLE
Add support for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 !.gitignore
 !.gitattributes
 !.mailmap
+!.github
 
 # Backup files
 *~


### PR DESCRIPTION
This commit adds support for Dependabot, which will automatically make PRs on a weekly basis (if necessary) for GitHub Actions and the Dockerfile.

As per my note in #7, this PR is the end result of splitting that PR into multiple PRs for tracking purposes.