### PR TITLE
Refactor Dockerfile - see description

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     privileged: true
     build:
       context: .
-    command: /bin/bash
     volumes:
       - ./:/usr/src:Z
       - /dev/:/dev/


### PR DESCRIPTION
- Use Debian Bullseye as `base` image.
- Use proper `LABEL` for authors/maintainers.
- Multi-stage builds.
- Download Rust via rustup.
- Combine RUN commands to reduce layers.