### PR TITLE
Don't flash blue LED when connected to bluetooth

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ bestool write-image out/open_source/open_source.bin --port /dev/ttyACM1
 - Quad tap : Volume Down
 
 ## Changing audio alerts
-The default audio alerts are stored in: 
+
+The default audio alerts are stored in:
 
 `config/_default_cfg_src_/res/en/`
 
@@ -82,9 +83,15 @@ name (ie `config/_default_cfg_src_/res/en/SOUND_POWER_ON.mp3`) and recompile wit
 ### Language support
 
 The `AUDIO` environment variable can be set when running the `build.sh` script to load sound files
-for languages other than the default English. For example, running `AUDIO=cn ./build.sh` will load sounds files from 
-`config/_default_cfg_src_/res/cn/` instead of the default `en/` folder. 
+for languages other than the default English. For example, running `AUDIO=cn ./build.sh` will load sounds files from
+`config/_default_cfg_src_/res/cn/` instead of the default `en/` folder.
 
-The current languages supported with sound files are English (`en`) and Chinese (`cn`). Other languages 
-(or other sets of custom sounds) may be added by adding all the correct sound files into a 
+The current languages supported with sound files are English (`en`) and Chinese (`cn`). Other languages
+(or other sets of custom sounds) may be added by adding all the correct sound files into a
 `config/_default_cfg_src_/res/<custom_sounds>/` directory and building with `AUDIO=<custom_sounds> ./build.sh`.
+
+### Blue light when connected
+
+The firmware can be configured to either have a blinking blue light when connected or not.
+Build with `CONNECTED_BLUE_LIGHT=1 ./build.sh` to enable blinking when connected,
+or `CONNECTED_BLUE_LIGHT=0 ./build.sh` (or just the default `./build.sh`) to keep the LEDs off when connected.

--- a/config/_default_cfg_src_/app_status_ind.c
+++ b/config/_default_cfg_src_/app_status_ind.c
@@ -173,6 +173,7 @@ int app_status_indication_set(APP_STATUS_INDICATION_T status) {
     app_pwl_start(APP_PWL_ID_1);
     break;
   case APP_STATUS_INDICATION_CONNECTED:
+#ifdef DISABLE_CONNECTED_BLUE_LIGHT
     cfg0.part[0].level = 0;
     cfg0.part[0].time = (500);
     cfg0.parttotal = 1;
@@ -183,6 +184,27 @@ int app_status_indication_set(APP_STATUS_INDICATION_T status) {
     app_pwl_start(APP_PWL_ID_0);
     app_pwl_setup(APP_PWL_ID_1, &cfg0);
     app_pwl_start(APP_PWL_ID_1);
+#else
+    cfg0.part[0].level = 1;
+    cfg0.part[0].time = (500);
+    cfg0.part[1].level = 0;
+    cfg0.part[1].time = (3000);
+    cfg0.parttotal = 2;
+    cfg0.startlevel = 1;
+    cfg0.periodic = true;
+
+    cfg1.part[0].level = 0;
+    cfg1.part[0].time = (500);
+    cfg1.part[1].level = 0;
+    cfg1.part[1].time = (3000);
+    cfg1.parttotal = 2;
+    cfg1.startlevel = 0;
+    cfg1.periodic = true;
+    app_pwl_setup(APP_PWL_ID_0, &cfg0);
+    app_pwl_start(APP_PWL_ID_0);
+    app_pwl_setup(APP_PWL_ID_1, &cfg1);
+    app_pwl_start(APP_PWL_ID_1);
+#endif
     break;
   case APP_STATUS_INDICATION_CHARGING:
     cfg1.part[0].level = 1;

--- a/config/_default_cfg_src_/app_status_ind.c
+++ b/config/_default_cfg_src_/app_status_ind.c
@@ -173,24 +173,15 @@ int app_status_indication_set(APP_STATUS_INDICATION_T status) {
     app_pwl_start(APP_PWL_ID_1);
     break;
   case APP_STATUS_INDICATION_CONNECTED:
-    cfg0.part[0].level = 1;
+    cfg0.part[0].level = 0;
     cfg0.part[0].time = (500);
-    cfg0.part[1].level = 0;
-    cfg0.part[1].time = (3000);
-    cfg0.parttotal = 2;
-    cfg0.startlevel = 1;
-    cfg0.periodic = true;
+    cfg0.parttotal = 1;
+    cfg0.startlevel = 0;
+    cfg0.periodic = false;
 
-    cfg1.part[0].level = 0;
-    cfg1.part[0].time = (500);
-    cfg1.part[1].level = 0;
-    cfg1.part[1].time = (3000);
-    cfg1.parttotal = 2;
-    cfg1.startlevel = 0;
-    cfg1.periodic = true;
     app_pwl_setup(APP_PWL_ID_0, &cfg0);
     app_pwl_start(APP_PWL_ID_0);
-    app_pwl_setup(APP_PWL_ID_1, &cfg1);
+    app_pwl_setup(APP_PWL_ID_1, &cfg0);
     app_pwl_start(APP_PWL_ID_1);
     break;
   case APP_STATUS_INDICATION_CHARGING:

--- a/config/common.mk
+++ b/config/common.mk
@@ -87,6 +87,9 @@ export VOICE_DETECTOR_EN ?= 0
 # 1 to use 8K sample rate for VAD, 0 to use 16K sample rate for VAD
 VAD_USE_8K_SAMPLE_RATE ?= 0
 
+# 1 to enable the blue flashing light when connected, 0 to disable
+CONNECTED_BLUE_LIGHT ?= 0
+
 # -------------------------------------------
 # Root Option Dependencies
 # -------------------------------------------
@@ -188,6 +191,10 @@ endif
 ifneq ($(filter apps/ tests/speech_test/ tests/ota_boot/, $(core-y)),)
 export BT_APP ?= 1
 FULL_APP_PROJECT ?= 1
+endif
+
+ifeq ($(strip $(CONNECTED_BLUE_LIGHT)),0)
+KBUILD_CPPFLAGS += -DDISABLE_CONNECTED_BLUE_LIGHT
 endif
 
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvv


### PR DESCRIPTION
Maybe this is just me, feel free to close this if it is, but I really dislike the flashing of the blue light when the buds are connected. I think it's completely unnecessary and even a bit confusing.

This seemed to work if I completely removed the code in the `APP_STATUS_INDICATION_CONNECTED` case, but that seems to me like it would just keep the LED in the state it is in before it connected. Let me know if that assumption is wrong.