### PR TITLE
Apply changes suggested by shellcheck

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -6,7 +6,7 @@ mkdir -p "$BKPPATH"
 
 NOW=$(date +%s)
 
-num=$(ls -l /dev/ttyACM* | rev | cut -c 1)
+num=$(find /dev -name 'ttyACM*' | sort | rev | cut -c 1)
 echo com is: "$num"
 mapfile -t splitPorts <<< "$num"
 echo "This tool assumes your buds are the only thing connected and are enumerated {right,left} order. YMMV"

--- a/backup.sh
+++ b/backup.sh
@@ -1,21 +1,20 @@
-#! /bin/bash
+#!/bin/bash
 
 BKPPATH="firmware-backups"
 
-mkdir -p $BKPPATH
+mkdir -p "$BKPPATH"
 
 NOW=$(date +%s)
 
 num=$(ls -l /dev/ttyACM* | rev | cut -c 1)
-echo com is:$num
-splitPorts=($num)
+echo com is: "$num"
+mapfile -t splitPorts <<< "$num"
 echo "This tool assumes your buds are the only thing connected and are enumerated {right,left} order. YMMV"
 echo "Right bud is at ${splitPorts[0]}"
 echo "Left bud is at ${splitPorts[1]}"
 
 echo "Please disconnect and reconnect the bud on the right"
-
-bestool read-image --port /dev/ttyACM${splitPorts[0]} $BKPPATH/firmware-$NOW-${splitPorts[0]}.bin.bkp
+bestool read-image --port "/dev/ttyACM${splitPorts[0]}" "${BKPPATH}/firmware-${NOW}-${splitPorts[0]}.bin.bkp"
 
 echo "Please disconnect and reconnect the bud on the left"
-bestool read-image --port /dev/ttyACM${splitPorts[1]} $BKPPATH/firmware-$NOW-${splitPorts[1]}.bin.bkp
+bestool read-image --port "/dev/ttyACM${splitPorts[1]}" "${BKPPATH}/firmware-${NOW}-${splitPorts[1]}.bin.bkp"

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
-make -j T=open_source DEBUG=1 >log.txt 2>&1
-
-if [ $? -eq 0 ]; then
+if make -j "$(nproc)" T=open_source DEBUG=1 >log.txt 2>&1; then
 	echo "build success"
 else
 	echo "build failed and call log.txt"
-	cat log.txt | grep "error:*"
+	grep "error:" log.txt
 fi

--- a/clear.sh
+++ b/clear.sh
@@ -1,2 +1,3 @@
-#!/bin/bash
-make T=open_source -j DEBUG=1 clean
+#!/bin/sh
+
+make -j "$(nproc)" T=open_source DEBUG=1 clean

--- a/download.sh
+++ b/download.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-num=$(ls -l /dev/ttyACM* | rev | cut -c 1)
+num=$(find /dev -name 'ttyACM*' | sort | rev | cut -c 1)
 echo com is: "$num"
 mapfile -t splitPorts <<< "$num"
 echo "This tool assumes your buds are the only thing connected and are enumerated {right,left} order. YMMV"

--- a/download.sh
+++ b/download.sh
@@ -1,15 +1,14 @@
-#! /bin/bash
+#!/bin/bash
 
 num=$(ls -l /dev/ttyACM* | rev | cut -c 1)
-echo com is:$num
-splitPorts=($num)
+echo com is: "$num"
+mapfile -t splitPorts <<< "$num"
 echo "This tool assumes your buds are the only thing connected and are enumerated {right,left} order. YMMV"
 echo "Right bud is at ${splitPorts[0]}"
 echo "Left bud is at ${splitPorts[1]}"
 
 echo "Please disconnect and reconnect the bud on the right"
-
-bestool write-image out/open_source/open_source.bin --port /dev/ttyACM${splitPorts[0]}
+bestool write-image out/open_source/open_source.bin --port "/dev/ttyACM${splitPorts[0]}"
 
 echo "Please disconnect and reconnect the bud on the left"
-bestool write-image out/open_source/open_source.bin --port /dev/ttyACM${splitPorts[1]}
+bestool write-image out/open_source/open_source.bin --port "/dev/ttyACM${splitPorts[1]}"

--- a/uart_log.sh
+++ b/uart_log.sh
@@ -1,5 +1,5 @@
-#! /bin/bash
+#!/bin/sh
 
-num=$(ls -l /dev/ttyUSB* | rev | cut -c 1)
+num=$(find /dev -name 'ttyUSB*' | rev | cut -c 1)
 echo "$num"
 sudo minicom "port$num"

--- a/uart_log.sh
+++ b/uart_log.sh
@@ -1,6 +1,5 @@
 #! /bin/bash
 
 num=$(ls -l /dev/ttyUSB* | rev | cut -c 1)
-#num=1
-echo $num
-sudo minicom port$num
+echo "$num"
+sudo minicom "port$num"


### PR DESCRIPTION
Apply some suggestions from `shellcheck`. It also suggests replacing the `ls -l` with `find`, which I agree with, but that changes the order the files get outputted in. This means that the left/right is even less reliable.