### PR TITLE
fix(makefile): Use shell-builtins in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ KBUILD_OUTPUT := $(shell ( if not exist $(KBUILD_OUTPUT)\ mkdir $(KBUILD_OUTPUT)
 KBUILD_OUTPUT := $(subst \,/,$(KBUILD_OUTPUT))
 else
 KBUILD_OUTPUT := $(shell mkdir -p $(KBUILD_OUTPUT) && cd $(KBUILD_OUTPUT) \
-                         && /bin/pwd)
+                         && pwd)
 endif
 
 $(if $(KBUILD_OUTPUT),, \

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -322,7 +322,7 @@ archive-cmd = ( ( echo create $@ && \
   echo end ) | $(AR) -M )
 else
 # Command "/bin/echo -e" cannot work on Apple Mac machines, so we use "/usr/bin/printf" instead
-archive-cmd = ( /usr/bin/printf 'create $@\n\
+archive-cmd = ( printf 'create $@\n\
   addmod $(subst $(space),$(comma),$(strip $(filter-out %.a %.cpp,$(1))))\n\
   $(foreach o,$(filter %.a,$(1)),addlib $o\n)save\nend' | $(AR) -M )
 endif


### PR DESCRIPTION
This improves portability, especially on systems like NixOS, where `/bin/pwd` and `/usr/bin/printf` do not exist.