### PR TITLE
refactor(scripts): Use `#!/usr/bin/env` as part of shebang

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BKPPATH="firmware-backups"
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if make -j "$(nproc)" T=open_source DEBUG=1 >log.txt 2>&1; then
 	echo "build success"

--- a/clear.sh
+++ b/clear.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 make -j "$(nproc)" T=open_source DEBUG=1 clean

--- a/convert.sh
+++ b/convert.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 txt_to_wav() {
   hash="$(md5sum "$1" | cut -d ' ' -f 1)"

--- a/download.sh
+++ b/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 num=$(find /dev -name 'ttyACM*' | sort | rev | cut -c 1)
 echo com is: "$num"

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env sh
 docker-compose run --rm builder

--- a/uart_log.sh
+++ b/uart_log.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 num=$(find /dev -name 'ttyUSB*' | rev | cut -c 1)
 echo "$num"


### PR DESCRIPTION
This resolves build errors in systems like NixOS, where `/bin/bash` doesn't exist.