### PR TITLE
Fix container builds on forks

### DIFF
--- a/.github/workflows/build-and-push-to-registry.yml
+++ b/.github/workflows/build-and-push-to-registry.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   build-and-push-images:
+    if: ${{ github.repository == 'pine64/OpenPineBuds' }}
     name: Build and push container image for PineBuds Pro SDK to GHCR.io
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR changes the 'build-and-push-to-registry' workflow to only run on the Pine64 repository, which prevents image pushing errors occurring.

By doing this, we ensure the container images only come from the Pine64 OpenPineBuds repository.