### PR TITLE
compose: Use repository's container image for dev env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     stdin_open: true
     tty: true
     privileged: true
+    image: "ghcr.io/pine64/openpinebuds:latest-sdk"
     build:
       context: .
     volumes:


### PR DESCRIPTION
This changes the `docker-compose.yml` file to use the Pine64 OpenPineBuds repository's container image for the development environment, but the user has the option to build from scratch.