### PR TITLE
Limit container workflow runs to `main` branch *only*

### DIFF
--- a/.github/workflows/build-and-push-to-registry.yml
+++ b/.github/workflows/build-and-push-to-registry.yml
@@ -1,6 +1,7 @@
 name: Container image builder workflow
 on:
   push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This limits the container workflow from building on non-`main` branches.

Otherwise, we have unstable and WIP container images available.