### PR TITLE
main: key_handler.cpp: Remove redundant checks

### DIFF
--- a/apps/main/key_handler.cpp
+++ b/apps/main/key_handler.cpp
@@ -120,6 +120,24 @@ void send_prev_track(void) {
 }
 void app_key_single_tap(APP_KEY_STATUS *status, void *param) {
   TRACE(2, "%s event %d", __func__, status->event);
+  /*
+  if (!app_tws_ibrt_tws_link_connected()) {
+    // No other bud paired
+    TRACE(0, "Handling %s in single bud mode", __func__);
+    send_play_pause();
+  } else {
+    // Bud's are working as a pair
+    if (app_tws_is_left_side()) {
+      TRACE(0, "Handling %s as left bud", __func__);
+      // Lefty
+      send_play_pause();
+    } else {
+      TRACE(0, "Handling %s as right bud", __func__);
+      // Righty
+      send_play_pause();
+    }
+  }
+  */
   send_play_pause();
 }
 void app_key_double_tap(APP_KEY_STATUS *status, void *param) {

--- a/apps/main/key_handler.cpp
+++ b/apps/main/key_handler.cpp
@@ -120,23 +120,7 @@ void send_prev_track(void) {
 }
 void app_key_single_tap(APP_KEY_STATUS *status, void *param) {
   TRACE(2, "%s event %d", __func__, status->event);
-
-  if (!app_tws_ibrt_tws_link_connected()) {
-    // No other bud paired
-    TRACE(0, "Handling %s in single bud mode", __func__);
-    send_play_pause();
-  } else {
-    // Bud's are working as a pair
-    if (app_tws_is_left_side()) {
-      TRACE(0, "Handling %s as left bud", __func__);
-      // Lefty
-      send_play_pause();
-    } else {
-      TRACE(0, "Handling %s as right bud", __func__);
-      // Righty
-      send_play_pause();
-    }
-  }
+  send_play_pause();
 }
 void app_key_double_tap(APP_KEY_STATUS *status, void *param) {
   TRACE(2, "%s event %d", __func__, status->event);
@@ -186,15 +170,6 @@ void app_key_quad_tap(APP_KEY_STATUS *status, void *param) {
     // No other bud paired
     TRACE(0, "Handling %s in single bud mode", __func__);
     send_vol_down();
-  } else {
-    // Bud's are working as a pair
-    if (app_tws_is_left_side()) {
-      TRACE(0, "Handling %s as left bud", __func__);
-      // Lefty
-    } else {
-      TRACE(0, "Handling %s as right bud", __func__);
-      // Righty
-    }
   }
 }
 


### PR DESCRIPTION
Hello,

I read trough few files and this one stood out mostly due to redundancy of the if checks.

The if checks would be useful if we did something different for single tap in single or tws mode but we currently use single tap in both modes for pause or play. So no need for the checks.

In quad tap we dont have any action for right or left earbud (I think when we add passtrough mode this could be a good place to enable it) so for now we can simply remove the checks :)

All in all its just a tiny cleanup of the file :)

(This has been tested and all works as expected on my pinebuds)