### PR TITLE
anc: Fix enable/disable from slave bud

### DIFF
--- a/apps/anc/src/app_anc.c
+++ b/apps/anc/src/app_anc.c
@@ -1531,13 +1531,6 @@ void app_anc_key(APP_KEY_STATUS *status, void *param) {
   bool flag = app_anc_work_status();
 
 #if defined(IBRT)
-  ibrt_ctrl_t *p_ibrt_ctrl = app_tws_ibrt_get_bt_ctrl_ctx();
-
-  TRACE(2, "[%s] current_role: %d", __func__, p_ibrt_ctrl->current_role);
-  if (p_ibrt_ctrl->current_role == IBRT_SLAVE) {
-    app_anc_notify_master_to_exchange_coef(0, 0);
-    return;
-  }
   app_anc_status_sync(!flag);
 #endif
   app_anc_status_post(!flag);

--- a/apps/main/key_handler.cpp
+++ b/apps/main/key_handler.cpp
@@ -1,0 +1,279 @@
+#include "a2dp_api.h"
+#include "app_audio.h"
+#include "app_battery.h"
+#include "app_ble_include.h"
+#include "app_bt.h"
+#include "app_bt_func.h"
+#include "app_bt_media_manager.h"
+#include "app_key.h"
+#include "app_overlay.h"
+#include "app_pwl.h"
+#include "app_status_ind.h"
+#include "app_thread.h"
+#include "app_tws_ibrt_cmd_handler.h"
+#include "app_utils.h"
+#include "apps.h"
+#include "audio_process.h"
+#include "audioflinger.h"
+#include "besbt.h"
+#include "bt_drv_interface.h"
+#include "bt_if.h"
+#include "btapp.h"
+#include "cmsis_os.h"
+#include "crash_dump_section.h"
+#include "factory_section.h"
+#include "gapm_task.h"
+#include "hal_bootmode.h"
+#include "hal_i2c.h"
+#include "hal_sleep.h"
+#include "hal_timer.h"
+#include "hal_trace.h"
+#include "list.h"
+#include "log_section.h"
+#include "me_api.h"
+#include "norflash_api.h"
+#include "nvrecord.h"
+#include "nvrecord_dev.h"
+#include "nvrecord_env.h"
+#include "os_api.h"
+#include "pmu.h"
+#include "stdio.h"
+#include "string.h"
+#include "tgt_hardware.h"
+
+#ifdef __INTERCONNECTION__
+#include "app_ble_mode_switch.h"
+#include "app_interconnection.h"
+#include "app_interconnection_ble.h"
+#include "app_interconnection_logic_protocol.h"
+#endif
+
+#include "app_ibrt_customif_cmd.h"
+#include "app_ibrt_customif_ui.h"
+#include "app_ibrt_if.h"
+#include "app_ibrt_ui_test.h"
+#include "app_ibrt_voice_report.h"
+#include "app_tws_if.h"
+
+#include "app_anc.h"
+
+extern struct BT_DEVICE_T app_bt_device;
+
+/*
+ * handling of touch events when the devices are turned on
+
+ * Both pods active:
+
+ * Right Ear:
+ * Single tap : Play/Pause
+ * Double tap : Next track
+ * Hold       : ANC on/off
+ * Triple tap : Volume Up
+ *
+ * Left Ear:
+ * Single tap : Play/Pause
+ * Double tap : Previous track
+ * Hold       : ANC on/off
+ * Triple tap : Volume Down
+
+ * Single pod active:
+
+ * Single tap : Play/Pause
+ * Double tap : Next track
+ * Hold       : Previous track
+ * Triple tap : Volume Up
+ * Quad   tap : Volume Down
+
+
+
+ * We use app_ibrt_if_start_user_action for handling actions, as this will apply
+ locally if we are link master
+ * OR send it over the link to the other bud if we are not
+*/
+
+void send_vol_up(void) {
+  uint8_t action[] = {IBRT_ACTION_LOCAL_VOLUP};
+  app_ibrt_if_start_user_action(action, sizeof(action));
+}
+void send_play_pause(void) {
+  if (app_bt_device.a2dp_play_pause_flag != 0) {
+    uint8_t action[] = {IBRT_ACTION_PAUSE};
+    app_ibrt_if_start_user_action(action, sizeof(action));
+  } else {
+    uint8_t action[] = {IBRT_ACTION_PLAY};
+    app_ibrt_if_start_user_action(action, sizeof(action));
+  }
+}
+void send_vol_down(void) {
+  uint8_t action[] = {IBRT_ACTION_LOCAL_VOLDN};
+  app_ibrt_if_start_user_action(action, sizeof(action));
+}
+
+void send_next_track(void) {
+  uint8_t action[] = {IBRT_ACTION_FORWARD};
+  app_ibrt_if_start_user_action(action, sizeof(action));
+}
+
+void send_prev_track(void) {
+  uint8_t action[] = {IBRT_ACTION_BACKWARD};
+  app_ibrt_if_start_user_action(action, sizeof(action));
+}
+
+void send_enable_disable_anc(void) {
+  uint8_t action[] = {IBRT_ACTION_ANC_NOTIRY_MASTER_EXCHANGE_COEF};
+  app_ibrt_if_start_user_action(action, sizeof(action));
+}
+
+void app_key_single_tap(APP_KEY_STATUS *status, void *param) {
+  TRACE(2, "%s event %d", __func__, status->event);
+
+  if (!app_tws_ibrt_tws_link_connected()) {
+    // No other bud paired
+    TRACE(0, "Handling %s in single bud mode", __func__);
+    send_play_pause();
+  } else {
+    // Bud's are working as a pair
+    if (app_tws_is_left_side()) {
+      TRACE(0, "Handling %s as left bud", __func__);
+      // Lefty
+      send_play_pause();
+    } else {
+      TRACE(0, "Handling %s as right bud", __func__);
+      // Righty
+      send_play_pause();
+    }
+  }
+}
+
+void app_key_double_tap(APP_KEY_STATUS *status, void *param) {
+  TRACE(2, "%s event %d", __func__, status->event);
+
+  if (!app_tws_ibrt_tws_link_connected()) {
+    // No other bud paired
+    TRACE(0, "Handling %s in single bud mode", __func__);
+    send_next_track();
+  } else {
+    // Bud's are working as a pair
+    if (app_tws_is_left_side()) {
+      TRACE(0, "Handling %s as left bud", __func__);
+      // Lefty
+      send_prev_track();
+    } else {
+      TRACE(0, "Handling %s as right bud", __func__);
+      // Righty
+      send_next_track();
+    }
+  }
+}
+
+void app_key_triple_tap(APP_KEY_STATUS *status, void *param) {
+  TRACE(2, "%s event %d", __func__, status->event);
+
+  if (!app_tws_ibrt_tws_link_connected()) {
+    // No other bud paired
+    TRACE(0, "Handling %s in single bud mode", __func__);
+    send_vol_up();
+  } else {
+    // Bud's are working as a pair
+    if (app_tws_is_left_side()) {
+      TRACE(0, "Handling %s as left bud", __func__);
+      // Lefty
+      send_vol_down();
+    } else {
+      TRACE(0, "Handling %s as right bud", __func__);
+      // Righty
+      send_vol_up();
+    }
+  }
+}
+
+void app_key_quad_tap(APP_KEY_STATUS *status, void *param) {
+  TRACE(2, "%s event %d", __func__, status->event);
+
+  if (!app_tws_ibrt_tws_link_connected()) {
+    // No other bud paired
+    TRACE(0, "Handling %s in single bud mode", __func__);
+    send_vol_down();
+  } else {
+    // Bud's are working as a pair
+    if (app_tws_is_left_side()) {
+      TRACE(0, "Handling %s as left bud", __func__);
+      // Lefty
+    } else {
+      TRACE(0, "Handling %s as right bud", __func__);
+      // Righty
+    }
+  }
+}
+
+void app_key_long_press_down(APP_KEY_STATUS *status, void *param) {
+  TRACE(2, "%s event %d", __func__, status->event);
+
+  if (!app_tws_ibrt_tws_link_connected()) {
+    // No other bud paired
+    TRACE(0, "Handling %s in single bud mode", __func__);
+    send_prev_track();
+  } else {
+    // Bud's are working as a pair
+    send_enable_disable_anc();
+  }
+}
+
+void app_key_reboot(APP_KEY_STATUS *status, void *param) {
+  TRACE(1, "%s ", __func__);
+  hal_cmu_sys_reboot();
+}
+
+void app_key_init(void) {
+  uint8_t i = 0;
+  TRACE(1, "%s", __func__);
+
+  const APP_KEY_HANDLE key_cfg[] = {
+
+      {{APP_KEY_CODE_PWR, APP_KEY_EVENT_CLICK}, "", app_key_single_tap, NULL},
+      {{APP_KEY_CODE_PWR, APP_KEY_EVENT_DOUBLECLICK},
+       "",
+       app_key_double_tap,
+       NULL},
+      {{APP_KEY_CODE_PWR, APP_KEY_EVENT_TRIPLECLICK},
+       "",
+       app_key_triple_tap,
+       NULL},
+      {{APP_KEY_CODE_PWR, APP_KEY_EVENT_ULTRACLICK},
+       "",
+       app_key_quad_tap,
+       NULL},
+      {{APP_KEY_CODE_PWR, APP_KEY_EVENT_LONGPRESS},
+       "",
+       app_key_long_press_down,
+       NULL},
+  };
+
+  app_key_handle_clear();
+  for (i = 0; i < (sizeof(key_cfg) / sizeof(APP_KEY_HANDLE)); i++) {
+    app_key_handle_registration(&key_cfg[i]);
+  }
+}
+
+void app_key_init_on_charging(void) {
+  uint8_t i = 0;
+  const APP_KEY_HANDLE key_cfg[] = {
+      {{APP_KEY_CODE_PWR, APP_KEY_EVENT_LONGLONGPRESS},
+       "long press reboot",
+       app_key_reboot,
+       NULL},
+  // {{APP_KEY_CODE_PWR,APP_KEY_EVENT_CLICK},"bt function
+  // key",app_dfu_key_handler, NULL},
+#ifdef __USB_COMM__
+      {{APP_KEY_CODE_PWR, APP_KEY_EVENT_LONGPRESS},
+       "usb cdc key",
+       app_usb_cdc_comm_key_handler,
+       NULL},
+#endif
+  };
+
+  TRACE(1, "%s", __func__);
+  for (i = 0; i < (sizeof(key_cfg) / sizeof(APP_KEY_HANDLE)); i++) {
+    app_key_handle_registration(&key_cfg[i]);
+  }
+}

--- a/services/app_ibrt/src/app_ibrt_keyboard.cpp
+++ b/services/app_ibrt/src/app_ibrt_keyboard.cpp
@@ -279,6 +279,7 @@ void app_ibrt_ui_perform_user_action(uint8_t *p_buff, uint16_t length) {
   ibrt_ctrl_t *p_ibrt_ctrl = app_tws_ibrt_get_bt_ctrl_ctx();
 
 #ifdef ANC_APP
+  //Doesnt actully get used!!!
   app_anc_cmd_receive_process(p_buff, length);
 #endif
 #ifdef ANC_WNR_ENABLED
@@ -351,6 +352,9 @@ void app_ibrt_ui_perform_user_action(uint8_t *p_buff, uint16_t length) {
   case IBRT_ACTION_LOCAL_VOLDN:
     app_bt_volumedown();
     app_ibrt_sync_volume_info();
+    break;
+  case IBRT_ACTION_ANC_NOTIRY_MASTER_EXCHANGE_COEF:
+    app_anc_key(NULL, NULL);
     break;
   default:
     TRACE(2, "%s unknown user action %d\n", __func__, p_buff[0]);


### PR DESCRIPTION
Switching ANC on or off from master bud has always worked since we could just straight up enable it and no command had to be sent.

When switching from slave bud we had to send the command to enable or disable it via app_anc_key. Issue is the handling of this request is from app_anc_cmd_receive_process which is not called without APP_ANC being defined.

This commit cleans up the way ANC is enabled and also fixes slave bud ANC switching by implementing the actual code path :)

Please note that the ANC testing branch should be rebased on top of main with this commit added.

I did my testing with main merged with anc_testing branch thus why the key_handling.cpp file :)