### PR TITLE
Update uart_log.sh for easier debugging

### DIFF
--- a/uart_log.sh
+++ b/uart_log.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env sh
 
-num=$(find /dev -name 'ttyUSB*' | rev | cut -c 1)
-echo "$num"
-sudo minicom "port$num"
+rightbud=/dev/serial/by-id/usb-wch.cn_USB_Dual_Serial_0123456789-if00
+leftbud=/dev/serial/by-id/usb-wch.cn_USB_Dual_Serial_0123456789-if02
+
+read -p "Which bud do you want to connect to UART for? L/R (default L): " -n 1 -r
+ttydev=$leftbud
+if [[ $REPLY =~ ^[Rr]$ ]]; then
+    ttydev=$rightbud
+fi
+sudo minicom -D $ttydev -b 2000000


### PR DESCRIPTION
Pick the serial device by ID, allowing us to safely predict the paths to find the left and right bud at
Also improve the script so it asks which bud we'd like to debug
Specify necessary minicom options, so it opens even if the default configuration is invalid