### PR TITLE
Enable LDAC in the build

### DIFF
--- a/config/open_source/target.mk
+++ b/config/open_source/target.mk
@@ -228,7 +228,7 @@ A2DP_LHDC_LARC ?= 1
 export FLASH_UNIQUE_ID ?= 1
 endif
 
-A2DP_LDAC_ON ?= 0
+A2DP_LDAC_ON ?= 1
 
 export TX_RX_PCM_MASK ?= 0
 
@@ -342,6 +342,8 @@ export BT_EXT_LNA ?=0
 export BT_EXT_PA ?=0
 
 ifeq ($(A2DP_LHDC_ON),1)
+AUDIO_BUFFER_SIZE := 140*1024
+else ifeq ($(A2DP_LDAC_ON),1)
 AUDIO_BUFFER_SIZE := 140*1024
 else
 AUDIO_BUFFER_SIZE := 100*1024

--- a/services/bt_app/app_bt_stream.cpp
+++ b/services/bt_app/app_bt_stream.cpp
@@ -3866,7 +3866,9 @@ int bt_sbc_player(enum PLAYER_OPER_T on, enum APP_SYSFREQ_FREQ_T freq) {
     }
 #endif
 #endif
-    freq = APP_SYSFREQ_52M;
+    if (freq < APP_SYSFREQ_52M) {
+      freq = APP_SYSFREQ_52M;
+    }
     app_sysfreq_req(APP_SYSFREQ_USER_BT_A2DP, freq);
     TRACE_AUD_STREAM_I("[A2DP_PLAYER] sysfreq %d", freq);
     TRACE_AUD_STREAM_I("[A2DP_PLAYER] sysfreq calc : %d\n",
@@ -3886,8 +3888,10 @@ int bt_sbc_player(enum PLAYER_OPER_T on, enum APP_SYSFREQ_FREQ_T freq) {
 
       else if (codec_type == BTIF_AVDTP_CODEC_TYPE_NON_A2DP) {
         TRACE(1, "current_a2dp_non_type %d", current_a2dp_non_type);
+        if (0) {
+        }
 #if defined(A2DP_LHDC_ON)
-        if (current_a2dp_non_type == A2DP_NON_CODEC_TYPE_LHDC) {
+        else if (current_a2dp_non_type == A2DP_NON_CODEC_TYPE_LHDC) {
           app_overlay_select(APP_OVERLAY_A2DP_LHDC);
         }
 #endif


### PR DESCRIPTION
- Permits LDAC to be enabled independenly of LHDC (they don't depend on each other and aren't related, other than they both go through the `BTIF_AVDTP_CODEC_TYPE_NON_A2DP` path and need a buffer bigger than 102400)
- Enables LDAC in the open_source target
- Fixes a bug/oversight in `bt_sbc_player` which caused system frequencies above 52M to be ignored (LDAC seems to target a 96k sample rate by default and thus needs 104M, as specified [here](https://github.com/pine64/OpenPineBuds/blob/main/services/bt_app/app_bt_stream.cpp#L3850) and [here](https://github.com/pine64/OpenPineBuds/blob/main/services/bt_app/app_bt_stream.cpp#L3862).)
I'm not sure if the [line](https://github.com/pine64/OpenPineBuds/blob/main/services/bt_app/app_bt_stream.cpp#L3869) was originally added for debug purposes (git blame traces it back to the initial commit, you can see it [here](https://github.com/pine64/OpenPineBuds/blob/235a402c8cd13f6c3f80e147384d10308ea2c1c9/services/bt_app/app_bt_stream.cpp#L3685)), so its possible that the hunk at services/bt_app/app_bt_stream.cpp#3869 could be removed entirely, or that my version may unnecessarily increase power usage in certain scenarios

I've tested it against my Xperia 1 V in both "Best effort" and "Sound quality preferred" modes and it seems to function without issues