### PR TITLE
Functional UART logging both inside and outside dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,11 @@ RUN apt-get update \
     && curl \
     https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-$(arch)-linux.tar.bz2 | tar -xj -C /src/
 
+RUN apt-get update \
+    && apt-get install -y \
+    minicom \
+    sudo
+
 ENV PATH="${PATH}:/src/gcc-arm-none-eabi-9-2019-q4-major/bin"
 COPY --from=rust_build /usr/src/bestool/bestool/target/release/bestool /usr/local/bin/bestool
 COPY . /usr/src

--- a/uart_log.sh
+++ b/uart_log.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 rightbud=/dev/serial/by-id/usb-wch.cn_USB_Dual_Serial_0123456789-if00
 leftbud=/dev/serial/by-id/usb-wch.cn_USB_Dual_Serial_0123456789-if02


### PR DESCRIPTION
Currently the docker image doesn't include minicom (or sudo), leaving the user to use the script outside the dev container.
This PR:
- Adds minicom and sudo to the docker image
- Switches the shebang line of `uart_log.sh` to bash. The -n option to read requires bash, and without this fix the script works inside the container (assuming you applied Dockerfile changes), but always selects the left bud