### PR TITLE
Fix the attribute `version` is obsolete warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   builder:
     stdin_open: true


### PR DESCRIPTION
Removes the version attribute from docker-compose.yml to prevent the warning. Apparently this attribute did not have any effect, so there shouldn't be any problems from removing it.